### PR TITLE
Refactor: Allow for easy addition of translation service providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,18 @@ This work is licensed under a
 
 *Disclaimer: This extension is not officially affiliated with Disney+.*
 
+## Adding New Translation Providers
+
+This extension is designed to support multiple translation service providers. If you want to add a new translation provider, please follow these steps:
+
+1.  **Understand the Interface**: Familiarize yourself with the required structure for a translation provider module by reading the interface definition located in `translation_providers/README.md`.
+2.  **Implement Your Provider**:
+    *   Create a new JavaScript file for your provider within the `translation_providers/` directory (e.g., `myNewProvider.js`).
+    *   You can use `translation_providers/deeplTranslate_example.js` as a starting template for your implementation.
+    *   Ensure your module exports an `async function translate(text, sourceLang, targetLang)` that adheres to the defined interface.
+3.  **Register Your Provider**:
+    *   In `background.js`, import your new provider module and add it to the `translationProviders` object. This object maps a unique provider ID (e.g., 'myNewProvider') to its display name and `translate` function.
+    *   In `popup/popup.js`, add your new provider's ID and display name to the `availableProviders` object. This will make it visible in the extension's settings popup.
+4.  **Test Thoroughly**: Ensure your new provider works correctly and handles errors gracefully.
+
+By following these guidelines, you can extend the translation capabilities of this extension.

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
     "https://translate.googleapis.com/*"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -19,6 +19,13 @@
         </div>
 
         <div class="setting">
+            <label for="translationProvider">Translation Provider:</label>
+            <select id="translationProvider">
+                <!-- Options will be populated by popup.js -->
+            </select>
+        </div>
+
+        <div class="setting">
             <label for="targetLanguage">Translate to:</label>
             <select id="targetLanguage">
                 <option value="en">English</option>

--- a/translation_providers/README.md
+++ b/translation_providers/README.md
@@ -1,0 +1,44 @@
+# Translation Provider Interface
+
+This document outlines the interface that all translation provider modules must adhere to for the Disney+ Dual Subtitles Chrome Extension.
+
+## Module Structure
+
+Each translation provider should be implemented as a separate JavaScript module file (e.g., `googleTranslate.js`, `someOtherProvider.js`).
+
+## `translate` Function
+
+Each module must export an asynchronous function named `translate`.
+
+### Signature
+
+`async function translate(text, sourceLang, targetLang)`
+
+### Parameters
+
+*   `text` (String): The text content to be translated.
+*   `sourceLang` (String): The language code of the original text (e.g., 'auto', 'en', 'ja'). The specific supported codes may depend on the provider.
+*   `targetLang` (String): The language code for the desired translation (e.g., 'en', 'es', 'zh-CN'). The specific supported codes will depend on the provider.
+
+### Returns
+
+*   `Promise<string>`: A Promise that resolves with the translated string. If the translation fails, the Promise should reject with an Error object containing a descriptive message.
+
+### Example
+
+```javascript
+// in myProvider.js
+export async function translate(text, sourceLang, targetLang) {
+    // Implementation specific to this provider
+    // ...
+    if (success) {
+        return "translated text";
+    } else {
+        throw new Error("Translation failed due to XYZ reason.");
+    }
+}
+```
+
+## Provider Registration (Conceptual)
+
+While not part of the module itself, providers will be registered and selected in `background.js`. Each provider should also have a user-friendly name for display in the extension's popup settings.

--- a/translation_providers/deeplTranslate_example.js
+++ b/translation_providers/deeplTranslate_example.js
@@ -1,0 +1,85 @@
+// disneyplus-dualsub-chrome-extension/translation_providers/deeplTranslate_example.js
+
+/**
+ * EXAMPLE PROVIDER: DeepL (Not fully implemented)
+ * 
+ * This is a placeholder to demonstrate how to add a new translation provider.
+ * To make this functional, you would need to:
+ * 1. Understand DeepL API requirements (authentication, endpoint, request format).
+ * 2. Implement the fetch call to the DeepL API.
+ * 3. Parse the DeepL API response to extract the translated text.
+ * 4. Handle errors appropriately.
+ * 5. Potentially add this provider to the `translationProviders` registry in `background.js`
+ *    and to the `availableProviders` list in `popup/popup.js` after full implementation.
+ */
+
+/**
+ * Translates text using a placeholder for the DeepL API.
+ *
+ * @param {string} text The text to translate.
+ * @param {string} sourceLang The source language code (e.g., 'auto', 'EN'). 
+ *                            DeepL might have different language codes than Google.
+ * @param {string} targetLang The target language code (e.g., 'ES', 'ZH').
+ *                            DeepL might have different language codes than Google.
+ * @returns {Promise<string>} A Promise that resolves with the translated text.
+ * @throws {Error} If the translation API request or processing fails.
+ */
+export async function translate(text, sourceLang, targetLang) {
+    console.log("DeeLProvider (Example): translate called with", { text, sourceLang, targetLang });
+
+    // --- BEGIN EXAMPLE IMPLEMENTATION (Placeholder) ---
+
+    // 1. Authentication (DeepL often requires an API key)
+    // const API_KEY = 'YOUR_DEEPL_API_KEY'; // Store and retrieve securely if needed
+    // if (!API_KEY) {
+    //     throw new Error("DeepL API key is missing.");
+    // }
+
+    // 2. API Endpoint and Request Configuration
+    // const DEEPL_API_URL = 'https://api-free.deepl.com/v2/translate'; // Or the pro version URL
+    // const params = new URLSearchParams({
+    //     auth_key: API_KEY,
+    //     text: text,
+    //     source_lang: sourceLang === 'auto' ? undefined : sourceLang, // DeepL might auto-detect if source_lang is omitted
+    //     target_lang: targetLang,
+    //     // Other parameters like 'formality', 'split_sentences' might be relevant
+    // });
+
+    try {
+        // 3. Fetch Call (Example - this part needs actual implementation)
+        // const response = await fetch(DEEPL_API_URL, {
+        //     method: 'POST', // Or 'GET' depending on DeepL's API
+        //     headers: {
+        //         'Content-Type': 'application/x-www-form-urlencoded', // Or 'application/json'
+        //     },
+        //     body: params.toString()
+        // });
+
+        // if (!response.ok) {
+        //     const errorData = await response.json(); // Or response.text()
+        //     console.error(`DeepL API Error: ${response.status}`, errorData);
+        //     throw new Error(`DeepL API request failed with status ${response.status}: ${errorData.message || 'Unknown error'}`);
+        // }
+
+        // const data = await response.json();
+
+        // 4. Response Parsing (Adjust based on actual DeepL response structure)
+        // if (data && data.translations && data.translations.length > 0) {
+        //     return data.translations[0].text;
+        // } else {
+        //     console.error("DeepLProvider: Invalid response structure from API", data);
+        //     throw new Error("DeepL translation response was empty or malformed.");
+        // }
+
+        // --- END EXAMPLE IMPLEMENTATION (Placeholder) ---
+        
+        // Placeholder return for the example:
+        return `[Example DeepL Translation of '${text}' to ${targetLang}]`;
+        // REMOVE THE ABOVE LINE AND UNCOMMENT/COMPLETE THE FETCH LOGIC FOR A REAL IMPLEMENTATION
+
+    } catch (error) {
+        console.error("DeepLProvider (Example): Translation error -", error);
+        // It's good practice to re-throw or throw a new error that background.js can handle
+        throw new Error(`DeepL (Example) Error: ${error.message}`);
+    }
+}

--- a/translation_providers/googleTranslate.js
+++ b/translation_providers/googleTranslate.js
@@ -1,0 +1,46 @@
+// disneyplus-dualsub-chrome-extension/translation_providers/googleTranslate.js
+
+/**
+ * Translates text using the Google Translate API.
+ *
+ * @param {string} text The text to translate.
+ * @param {string} sourceLang The source language code (e.g., 'auto', 'en').
+ * @param {string} targetLang The target language code (e.g., 'es', 'zh-CN').
+ * @returns {Promise<string>} A Promise that resolves with the translated text.
+ * @throws {Error} If the translation API request or processing fails.
+ */
+export async function translate(text, sourceLang, targetLang) {
+    const G_TRANSLATE_URL = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${sourceLang}&tl=${targetLang}&dt=t&q=${encodeURIComponent(text)}`;
+
+    try {
+        const response = await fetch(G_TRANSLATE_URL);
+        if (!response.ok) {
+            const errorText = await response.text();
+            console.error(`GoogleTranslate: API HTTP error! Status: ${response.status}, Response: ${errorText.substring(0, 200)}`);
+            throw new Error(`Translation API HTTP error ${response.status}.`);
+        }
+
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.includes("application/json")) {
+            const data = await response.json();
+            if (data && data[0] && Array.isArray(data[0]) && data[0][0] && typeof data[0][0][0] === 'string') {
+                return data[0].map(sentence => sentence[0]).join('');
+            } else {
+                console.error("GoogleTranslate: Translation JSON parsing failed or unexpected structure. Response data:", data);
+                throw new Error("Translation Error: Malformed JSON response from Google Translate.");
+            }
+        } else {
+            const textResponse = await response.text();
+            console.error(`GoogleTranslate: API did not return JSON. Content-Type: ${contentType}. Response (first 500 chars):`, textResponse.substring(0, 500));
+            if (textResponse.includes("<title>Google</title>") && textResponse.includes("unusual traffic")) {
+                throw new Error("Translation API blocked by Google: CAPTCHA or unusual traffic detected.");
+            }
+            throw new Error(`Translation API returned non-JSON (Content-Type: ${contentType}).`);
+        }
+    } catch (error) {
+        console.error("GoogleTranslate: API request/processing error:", error);
+        // Re-throw the error to be caught by the caller in background.js
+        // or provide a more specific error message if desired.
+        throw error; // Rethrowing the original error preserves its type and message
+    }
+}


### PR DESCRIPTION
This commit refactors the translation functionality to support multiple translation service providers.

Key changes:
- Defined a common interface for translation providers in `translation_providers/README.md`.
- Moved the existing Google Translate logic into its own module (`translation_providers/googleTranslate.js`) adhering to this interface.
- Updated `background.js` to manage a registry of translation providers, load your selection from `chrome.storage.sync`, and use the selected provider for translations.
- Added a dropdown menu in `popup/popup.html` and corresponding logic in `popup/popup.js` to allow you to select your preferred translation provider. Currently, Google Translate is the only option.
- Included an example provider module (`translation_providers/deeplTranslate_example.js`) to guide future implementations.
- Updated the main `README.md` with instructions on how to add new translation providers.

This architectural change makes it significantly easier to integrate alternative or new translation services in the future without major overhauls to the core logic.