### PR TITLE
Enhance subtitle handling by implementing platform-specific blacklisting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ WARP.md
 
 # Chrome extensions cannot load directories beginning with underscore
 __tests__/
+dist/

--- a/background/services/subtitleService.js
+++ b/background/services/subtitleService.js
@@ -229,7 +229,7 @@ class SubtitleService {
 
         // Step 2: Parse available languages from master playlist
         const availableLanguages =
-            this.parseAvailableSubtitleLanguages(masterPlaylistText);
+            await this.parseAvailableSubtitleLanguages(masterPlaylistText, 'disneyplus');
         this.logger.debug('Available subtitle languages', {
             languages: availableLanguages.map(
                 (lang) => `${lang.normalizedCode} (${lang.displayName})`
@@ -536,12 +536,71 @@ class SubtitleService {
     }
 
     /**
+     * Check if subtitle should be filtered based on platform blacklist
+     * @param {string} displayName - Subtitle display name
+     * @param {string} line - Full M3U8 line
+     * @param {string} platform - Platform name (disneyplus, netflix, generic)
+     * @param {Array<string>} blacklist - Blacklist keywords
+     * @returns {boolean} True if subtitle should be skipped
+     */
+    isSubtitleBlacklisted(displayName, line, platform, blacklist) {
+        if (!blacklist || blacklist.length === 0) {
+            return false;
+        }
+
+        const displayNameLower = displayName.toLowerCase();
+
+        for (const keyword of blacklist) {
+            const keywordLower = keyword.toLowerCase().trim();
+            if (!keywordLower) continue;
+
+            // Check if keyword is in display name
+            if (displayNameLower.includes(keywordLower)) {
+                this.logger.debug('Subtitle blacklisted by name', {
+                    platform,
+                    displayName,
+                    keyword,
+                });
+                return true;
+            }
+
+            // For attribute patterns (contains =), check the full line exactly
+            // This prevents "forced" from matching "FORCED=NO"
+            if (keywordLower.includes('=')) {
+                const lineLower = line.toLowerCase();
+                if (lineLower.includes(keywordLower)) {
+                    this.logger.debug('Subtitle blacklisted by attribute', {
+                        platform,
+                        displayName,
+                        keyword,
+                    });
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Parse available subtitle languages from master M3U8 playlist
      * Ported from original background script
+     * @param {string} masterPlaylistText - M3U8 master playlist content
+     * @param {string} platform - Platform name (disneyplus, netflix, generic)
+     * @returns {Promise<Array>} Array of subtitle language objects
      */
-    parseAvailableSubtitleLanguages(masterPlaylistText) {
+    async parseAvailableSubtitleLanguages(masterPlaylistText, platform = 'generic') {
         const lines = masterPlaylistText.split('\n');
         const languages = [];
+
+        // Get blacklist for this platform from configuration
+        const blacklistConfig = await configService.get('subtitleBlacklist');
+        const platformBlacklist = blacklistConfig?.[platform] || [];
+
+        this.logger.debug('Using subtitle blacklist', {
+            platform,
+            blacklist: platformBlacklist,
+        });
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i].trim();
@@ -554,6 +613,11 @@ class SubtitleService {
                     const languageCode = languageMatch[1];
                     const displayName = nameMatch[1];
                     const uri = uriMatch[1];
+
+                    // Check if subtitle is blacklisted
+                    if (this.isSubtitleBlacklisted(displayName, line, platform, platformBlacklist)) {
+                        continue;
+                    }
 
                     languages.push({
                         normalizedCode: normalizeLanguageCode(languageCode),

--- a/config/configSchema.js
+++ b/config/configSchema.js
@@ -112,6 +112,17 @@ export const configSchema = {
         scope: 'sync',
     },
 
+    // Platform-specific subtitle blacklist
+    subtitleBlacklist: {
+        defaultValue: {
+            disneyplus: ['--forced--', 'forced=yes'],
+            netflix: [],
+            generic: [],
+        },
+        type: Object,
+        scope: 'sync',
+    },
+
     // --- UI State Settings (local storage for better performance) ---
     appearanceAccordionOpen: {
         defaultValue: false,

--- a/config/configSchema.test.js
+++ b/config/configSchema.test.js
@@ -181,7 +181,7 @@ describe('configSchema', () => {
             expect(actualSettings).toEqual(
                 expect.arrayContaining(expectedSettings)
             );
-            expect(actualSettings.length).toBe(61);
+            expect(actualSettings.length).toBe(62);
         });
 
         it('should have correct scope distribution', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ export default {
     transform: {},
     moduleFileExtensions: ['js', 'json'],
     testMatch: ['**/tests/**/*.js', '**/?(*.)+(spec|test).js'],
+    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
     collectCoverageFrom: [
         'utils/**/*.js',
         'services/**/*.js',


### PR DESCRIPTION
This pull request enhances the subtitle language parsing logic by adding support for platform-specific subtitle blacklists, allowing the service to filter out unwanted subtitle tracks (such as "forced" subtitles) based on configurable keywords. The main changes introduce a new configuration option for blacklists and update the subtitle parsing flow to respect these settings.

**Subtitle filtering improvements:**

* Added a new `subtitleBlacklist` configuration option in `configSchema.js` to allow platform-specific blacklisting of subtitle keywords (e.g., filtering out "forced" subtitles on Disney+).
* Updated the `parseAvailableSubtitleLanguages` method in `subtitleService.js` to accept a `platform` parameter, fetch the appropriate blacklist from config, and use it when parsing subtitles.
* Implemented a new `isSubtitleBlacklisted` helper method in `subtitleService.js` that checks if a subtitle should be filtered out based on the blacklist and logs the filtering decision for debugging.
* Modified the subtitle parsing loop in `subtitleService.js` to skip blacklisted subtitles by invoking the new blacklist logic.
* Updated the call to `parseAvailableSubtitleLanguages` in the main subtitle fetching flow to specify the platform (currently 'disneyplus'), ensuring the correct blacklist is applied.

## Summary by Sourcery

Introduce platform-specific subtitle blacklisting to filter unwanted subtitle tracks based on configurable keywords and integrate it into the subtitle parsing workflow.

New Features:
- Add a `subtitleBlacklist` configuration option for defining per-platform subtitle filter keywords.
- Implement `isSubtitleBlacklisted` helper to check and log subtitle entries against the blacklist.
- Extend `parseAvailableSubtitleLanguages` to accept a `platform` parameter, fetch the corresponding blacklist, and skip matching subtitles.
- Update subtitle fetching flow to pass the platform identifier and apply blacklist filtering.